### PR TITLE
Bump Kahi UI to `0.5.5`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,12 @@
 			"name": "kahi-ui-template-sveltekit",
 			"version": "0.0.1",
 			"dependencies": {
-				"@kahi-ui/framework": "^0.5.0",
+				"@kahi-ui/framework": "^0.5.4",
 				"@lukeed/uuid": "^2.0.0",
 				"cookie": "^0.4.1"
 			},
 			"devDependencies": {
-				"@sveltejs/kit": "next",
+				"@sveltejs/kit": "^1.0.0-next.240",
 				"@types/cookie": "^0.4.0",
 				"@typescript-eslint/eslint-plugin": "^4.19.0",
 				"@typescript-eslint/parser": "^4.19.0",
@@ -172,11 +172,24 @@
 			"integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
 			"dev": true
 		},
-		"node_modules/@kahi-ui/framework": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/@kahi-ui/framework/-/framework-0.5.0.tgz",
-			"integrity": "sha512-Yl7YWgv8K+wbPpBPxim9lfeKaMEuBzGZ1hpYjU/GI+KkGZlUY0fhzxtbFxHrdIbXnhFxOqhTq/QrUIMbLD8wfQ==",
+		"node_modules/@js-temporal/polyfill": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@js-temporal/polyfill/-/polyfill-0.3.0.tgz",
+			"integrity": "sha512-cxxxis19j0WvK3+kUwKrXeXaDBaWxLeRfKqlVz7g50Cly6UgGs2p3wovH9zjtZ4TtjYHDR4De/880+aalduDZQ==",
 			"dependencies": {
+				"big-integer": "^1.6.51",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/@kahi-ui/framework": {
+			"version": "0.5.4",
+			"resolved": "https://registry.npmjs.org/@kahi-ui/framework/-/framework-0.5.4.tgz",
+			"integrity": "sha512-H02Fs/dRgf+6ezio+WKzVWie1iLHDdTpO4eY3UGPuKPMKgQx/VuFaZ7Tc0Eo/3i5B8wp2JNgLChYJFA3O/CxAg==",
+			"dependencies": {
+				"@js-temporal/polyfill": "^0.3.0",
 				"svelte": "^3.40.2"
 			}
 		},
@@ -235,9 +248,9 @@
 			}
 		},
 		"node_modules/@rollup/pluginutils": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.0.tgz",
-			"integrity": "sha512-TrBhfJkFxA+ER+ew2U2/fHbebhLT/l/2pRk0hfj9KusXUuRXd2v0R58AfaZK9VXDQ4TogOSEmICVrQAA3zFnHQ==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.2.tgz",
+			"integrity": "sha512-ROn4qvkxP9SyPeHaf7uQC/GPFY6L/OWy9+bd9AwcjOAWQwxRscoEyAUD8qCY5o5iL4jqQwoLk2kaTKJPb/HwzQ==",
 			"dev": true,
 			"dependencies": {
 				"estree-walker": "^2.0.1",
@@ -245,51 +258,52 @@
 			},
 			"engines": {
 				"node": ">= 8.0.0"
-			},
-			"peerDependencies": {
-				"rollup": "^1.20.0||^2.0.0"
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "1.0.0-next.124",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.124.tgz",
-			"integrity": "sha512-opqmEj/OXJbLEqN+V03mxHvNf53ALT0HUaCmfe5FwQ4Cy5xE8yTlJulB27stnqMPxCeTk5XaCdmN9vDQgd+khA==",
+			"version": "1.0.0-next.240",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.240.tgz",
+			"integrity": "sha512-cHdxdSKAdCuty2lYlRHXE4rJZuKd4wur9U63JtPwysTaReMEJl+s9J/LVvyBzaLW/13x8vm/kKqx+DDcI0udlA==",
 			"dev": true,
 			"dependencies": {
-				"@sveltejs/vite-plugin-svelte": "^1.0.0-next.12",
-				"cheap-watch": "^1.0.3",
+				"@sveltejs/vite-plugin-svelte": "^1.0.0-next.32",
 				"sade": "^1.7.4",
-				"vite": "^2.4.1"
+				"vite": "^2.7.2"
 			},
 			"bin": {
 				"svelte-kit": "svelte-kit.js"
 			},
 			"engines": {
-				"node": "^12.20 || >=14.13"
+				"node": ">=14.13"
 			},
 			"peerDependencies": {
-				"svelte": "^3.34.0"
+				"svelte": "^3.44.0"
 			}
 		},
 		"node_modules/@sveltejs/vite-plugin-svelte": {
-			"version": "1.0.0-next.12",
-			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.12.tgz",
-			"integrity": "sha512-cuyNkJ6leptfv+7qL/fWQ7EpGWdguosFOUI0z93oQUmFTcX7QxJ5h+QI3NQyktBzlKL/761L8BbG2hHNkVbLIQ==",
+			"version": "1.0.0-next.35",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.35.tgz",
+			"integrity": "sha512-PuhI+1L6xqn5gc6jiK4mHmeS8kf3c1E+IaAsJclHbZTNiPQdC5SiTM3cV0FAA4zhwHmXV6pjt8rRHRx8ouFv3g==",
 			"dev": true,
 			"dependencies": {
-				"@rollup/pluginutils": "^4.1.0",
-				"debug": "^4.3.2",
+				"@rollup/pluginutils": "^4.1.2",
+				"debug": "^4.3.3",
 				"kleur": "^4.1.4",
 				"magic-string": "^0.25.7",
-				"require-relative": "^0.8.7",
-				"svelte-hmr": "^0.14.5"
+				"svelte-hmr": "^0.14.9"
 			},
 			"engines": {
-				"node": "^12.20 || ^14.13.1 || >= 16"
+				"node": "^14.13.1 || >= 16"
 			},
 			"peerDependencies": {
-				"svelte": "^3.34.0",
-				"vite": "^2.3.7"
+				"diff-match-patch": "^1.0.5",
+				"svelte": "^3.44.0",
+				"vite": "^2.7.0"
+			},
+			"peerDependenciesMeta": {
+				"diff-match-patch": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@types/cookie": {
@@ -597,6 +611,14 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true
 		},
+		"node_modules/big-integer": {
+			"version": "1.6.51",
+			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+			"integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+			"engines": {
+				"node": ">=0.6"
+			}
+		},
 		"node_modules/binary-extensions": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -653,15 +675,6 @@
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
-		"node_modules/cheap-watch": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/cheap-watch/-/cheap-watch-1.0.3.tgz",
-			"integrity": "sha512-xC5CruMhLzjPwJ5ecUxGu1uGmwJQykUhqd2QrCrYbwvsFYdRyviu6jG9+pccwDXJR/OpmOTOJ9yLFunVgQu9wg==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/chokidar": {
 			"version": "3.5.2",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
@@ -701,12 +714,6 @@
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true
 		},
-		"node_modules/colorette": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
-			"integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
-			"dev": true
-		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -736,9 +743,9 @@
 			}
 		},
 		"node_modules/debug": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-			"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
 			"dev": true,
 			"dependencies": {
 				"ms": "2.1.2"
@@ -810,14 +817,254 @@
 			}
 		},
 		"node_modules/esbuild": {
-			"version": "0.12.15",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.15.tgz",
-			"integrity": "sha512-72V4JNd2+48eOVCXx49xoSWHgC3/cCy96e7mbXKY+WOWghN00cCmlGnwVLRhRHorvv0dgCyuMYBZlM2xDM5OQw==",
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.13.15.tgz",
+			"integrity": "sha512-raCxt02HBKv8RJxE8vkTSCXGIyKHdEdGfUmiYb8wnabnaEmHzyW7DCHb5tEN0xU8ryqg5xw54mcwnYkC4x3AIw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"bin": {
 				"esbuild": "bin/esbuild"
+			},
+			"optionalDependencies": {
+				"esbuild-android-arm64": "0.13.15",
+				"esbuild-darwin-64": "0.13.15",
+				"esbuild-darwin-arm64": "0.13.15",
+				"esbuild-freebsd-64": "0.13.15",
+				"esbuild-freebsd-arm64": "0.13.15",
+				"esbuild-linux-32": "0.13.15",
+				"esbuild-linux-64": "0.13.15",
+				"esbuild-linux-arm": "0.13.15",
+				"esbuild-linux-arm64": "0.13.15",
+				"esbuild-linux-mips64le": "0.13.15",
+				"esbuild-linux-ppc64le": "0.13.15",
+				"esbuild-netbsd-64": "0.13.15",
+				"esbuild-openbsd-64": "0.13.15",
+				"esbuild-sunos-64": "0.13.15",
+				"esbuild-windows-32": "0.13.15",
+				"esbuild-windows-64": "0.13.15",
+				"esbuild-windows-arm64": "0.13.15"
 			}
+		},
+		"node_modules/esbuild-android-arm64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.13.15.tgz",
+			"integrity": "sha512-m602nft/XXeO8YQPUDVoHfjyRVPdPgjyyXOxZ44MK/agewFFkPa8tUo6lAzSWh5Ui5PB4KR9UIFTSBKh/RrCmg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"android"
+			]
+		},
+		"node_modules/esbuild-darwin-64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.13.15.tgz",
+			"integrity": "sha512-ihOQRGs2yyp7t5bArCwnvn2Atr6X4axqPpEdCFPVp7iUj4cVSdisgvEKdNR7yH3JDjW6aQDw40iQFoTqejqxvQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/esbuild-darwin-arm64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.13.15.tgz",
+			"integrity": "sha512-i1FZssTVxUqNlJ6cBTj5YQj4imWy3m49RZRnHhLpefFIh0To05ow9DTrXROTE1urGTQCloFUXTX8QfGJy1P8dQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			]
+		},
+		"node_modules/esbuild-freebsd-64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.13.15.tgz",
+			"integrity": "sha512-G3dLBXUI6lC6Z09/x+WtXBXbOYQZ0E8TDBqvn7aMaOCzryJs8LyVXKY4CPnHFXZAbSwkCbqiPuSQ1+HhrNk7EA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/esbuild-freebsd-arm64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.13.15.tgz",
+			"integrity": "sha512-KJx0fzEDf1uhNOZQStV4ujg30WlnwqUASaGSFPhznLM/bbheu9HhqZ6mJJZM32lkyfGJikw0jg7v3S0oAvtvQQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"freebsd"
+			]
+		},
+		"node_modules/esbuild-linux-32": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.13.15.tgz",
+			"integrity": "sha512-ZvTBPk0YWCLMCXiFmD5EUtB30zIPvC5Itxz0mdTu/xZBbbHJftQgLWY49wEPSn2T/TxahYCRDWun5smRa0Tu+g==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/esbuild-linux-64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.13.15.tgz",
+			"integrity": "sha512-eCKzkNSLywNeQTRBxJRQ0jxRCl2YWdMB3+PkWFo2BBQYC5mISLIVIjThNtn6HUNqua1pnvgP5xX0nHbZbPj5oA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/esbuild-linux-arm": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.13.15.tgz",
+			"integrity": "sha512-wUHttDi/ol0tD8ZgUMDH8Ef7IbDX+/UsWJOXaAyTdkT7Yy9ZBqPg8bgB/Dn3CZ9SBpNieozrPRHm0BGww7W/jA==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/esbuild-linux-arm64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.13.15.tgz",
+			"integrity": "sha512-bYpuUlN6qYU9slzr/ltyLTR9YTBS7qUDymO8SV7kjeNext61OdmqFAzuVZom+OLW1HPHseBfJ/JfdSlx8oTUoA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/esbuild-linux-mips64le": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.13.15.tgz",
+			"integrity": "sha512-KlVjIG828uFPyJkO/8gKwy9RbXhCEUeFsCGOJBepUlpa7G8/SeZgncUEz/tOOUJTcWMTmFMtdd3GElGyAtbSWg==",
+			"cpu": [
+				"mips64el"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/esbuild-linux-ppc64le": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.13.15.tgz",
+			"integrity": "sha512-h6gYF+OsaqEuBjeesTBtUPw0bmiDu7eAeuc2OEH9S6mV9/jPhPdhOWzdeshb0BskRZxPhxPOjqZ+/OqLcxQwEQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"linux"
+			]
+		},
+		"node_modules/esbuild-netbsd-64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.13.15.tgz",
+			"integrity": "sha512-3+yE9emwoevLMyvu+iR3rsa+Xwhie7ZEHMGDQ6dkqP/ndFzRHkobHUKTe+NCApSqG5ce2z4rFu+NX/UHnxlh3w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"netbsd"
+			]
+		},
+		"node_modules/esbuild-openbsd-64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.13.15.tgz",
+			"integrity": "sha512-wTfvtwYJYAFL1fSs8yHIdf5GEE4NkbtbXtjLWjM3Cw8mmQKqsg8kTiqJ9NJQe5NX/5Qlo7Xd9r1yKMMkHllp5g==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"openbsd"
+			]
+		},
+		"node_modules/esbuild-sunos-64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.13.15.tgz",
+			"integrity": "sha512-lbivT9Bx3t1iWWrSnGyBP9ODriEvWDRiweAs69vI+miJoeKwHWOComSRukttbuzjZ8r1q0mQJ8Z7yUsDJ3hKdw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"sunos"
+			]
+		},
+		"node_modules/esbuild-windows-32": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.13.15.tgz",
+			"integrity": "sha512-fDMEf2g3SsJ599MBr50cY5ve5lP1wyVwTe6aLJsM01KtxyKkB4UT+fc5MXQFn3RLrAIAZOG+tHC+yXObpSn7Nw==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/esbuild-windows-64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.13.15.tgz",
+			"integrity": "sha512-9aMsPRGDWCd3bGjUIKG/ZOJPKsiztlxl/Q3C1XDswO6eNX/Jtwu4M+jb6YDH9hRSUflQWX0XKAfWzgy5Wk54JQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			]
+		},
+		"node_modules/esbuild-windows-arm64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.15.tgz",
+			"integrity": "sha512-zzvyCVVpbwQQATaf3IG8mu1IwGEiDxKkYUdA4FpoCHi1KtPa13jeScYDjlW0Qh+ebWzpKfR2ZwvqAQkSWNcKjA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"optional": true,
+			"os": [
+				"win32"
+			]
 		},
 		"node_modules/escape-string-regexp": {
 			"version": "4.0.0",
@@ -1357,9 +1604,9 @@
 			}
 		},
 		"node_modules/is-core-module": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
-			"integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
+			"integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
 			"dev": true,
 			"dependencies": {
 				"has": "^1.0.3"
@@ -1570,9 +1817,9 @@
 			"dev": true
 		},
 		"node_modules/nanoid": {
-			"version": "3.1.23",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-			"integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
+			"integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
 			"dev": true,
 			"bin": {
 				"nanoid": "bin/nanoid.cjs"
@@ -1667,6 +1914,12 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/picocolors": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+			"dev": true
+		},
 		"node_modules/picomatch": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -1680,14 +1933,14 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.3.5",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.5.tgz",
-			"integrity": "sha512-NxTuJocUhYGsMiMFHDUkmjSKT3EdH4/WbGF6GCi1NDGk+vbcUTun4fpbOqaPtD8IIsztA2ilZm2DhYCuyN58gA==",
+			"version": "8.4.5",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.5.tgz",
+			"integrity": "sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==",
 			"dev": true,
 			"dependencies": {
-				"colorette": "^1.2.2",
-				"nanoid": "^3.1.23",
-				"source-map-js": "^0.6.2"
+				"nanoid": "^3.1.30",
+				"picocolors": "^1.0.0",
+				"source-map-js": "^1.0.1"
 			},
 			"engines": {
 				"node": "^10 || ^12 || >=14"
@@ -1799,20 +2052,18 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/require-relative": {
-			"version": "0.8.7",
-			"resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
-			"integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
-			"dev": true
-		},
 		"node_modules/resolve": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-			"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+			"version": "1.22.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
+			"integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
 			"dev": true,
 			"dependencies": {
-				"is-core-module": "^2.2.0",
-				"path-parse": "^1.0.6"
+				"is-core-module": "^2.8.1",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
+			},
+			"bin": {
+				"resolve": "bin/resolve"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -1853,9 +2104,9 @@
 			}
 		},
 		"node_modules/rollup": {
-			"version": "2.53.1",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.53.1.tgz",
-			"integrity": "sha512-yiTCvcYXZEulNWNlEONOQVlhXA/hgxjelFSjNcrwAAIfYx/xqjSHwqg/cCaWOyFRKr+IQBaXwt723m8tCaIUiw==",
+			"version": "2.66.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.66.1.tgz",
+			"integrity": "sha512-crSgLhSkLMnKr4s9iZ/1qJCplgAgrRY+igWv8KhG/AjKOJ0YX/WpmANyn8oxrw+zenF3BXWDLa7Xl/QZISH+7w==",
 			"dev": true,
 			"bin": {
 				"rollup": "dist/bin/rollup"
@@ -1974,9 +2225,9 @@
 			}
 		},
 		"node_modules/source-map-js": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
-			"integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -2056,10 +2307,22 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/supports-preserve-symlinks-flag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/svelte": {
-			"version": "3.42.1",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.42.1.tgz",
-			"integrity": "sha512-XtExLd2JAU3T7M2g/DkO3UNj/3n1WdTXrfL63OZ5nZq7nAqd9wQw+lR4Pv/wkVbrWbAIPfLDX47UjFdmnY+YtQ==",
+			"version": "3.46.2",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.46.2.tgz",
+			"integrity": "sha512-RXSAtYNefe01Sb1lXtZ2I+gzn3t/h/59hoaRNeRrm8IkMIu6BSiAkbpi41xb+C44x54YKnbk9+dtfs3pM4hECA==",
 			"engines": {
 				"node": ">= 8"
 			}
@@ -2088,9 +2351,9 @@
 			}
 		},
 		"node_modules/svelte-hmr": {
-			"version": "0.14.5",
-			"resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.14.5.tgz",
-			"integrity": "sha512-3O+kkbT1XKAomKB0LRcdY8JUTzONoNZ8rSH4iEdG7piIYsw+KkXpTkbbU1Sc1yPY4onfXkmCrHElYsxr0V1Snw==",
+			"version": "0.14.9",
+			"resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.14.9.tgz",
+			"integrity": "sha512-bKE9+4qb4sAnA+TKHiYurUl970rjA0XmlP9TEP7K/ncyWz3m81kA4HOgmlZK/7irGK7gzZlaPDI3cmf8fp/+tg==",
 			"dev": true,
 			"peerDependencies": {
 				"svelte": ">=3.19.0"
@@ -2218,10 +2481,9 @@
 			}
 		},
 		"node_modules/tslib": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-			"integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
-			"dev": true
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"node_modules/tsutils": {
 			"version": "3.21.0",
@@ -2297,24 +2559,40 @@
 			"dev": true
 		},
 		"node_modules/vite": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-2.4.1.tgz",
-			"integrity": "sha512-4BpKRis9uxIqPfIEcJ18LTBsamqnDFxTx45CXwagHjNltHa6PFEvf8Pe6OpgIHb0OyWT30OXOSSQvdOaX4OBiQ==",
+			"version": "2.7.13",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-2.7.13.tgz",
+			"integrity": "sha512-Mq8et7f3aK0SgSxjDNfOAimZGW9XryfHRa/uV0jseQSilg+KhYDSoNb9h1rknOy6SuMkvNDLKCYAYYUMCE+IgQ==",
 			"dev": true,
 			"dependencies": {
-				"esbuild": "^0.12.8",
-				"postcss": "^8.3.5",
+				"esbuild": "^0.13.12",
+				"postcss": "^8.4.5",
 				"resolve": "^1.20.0",
-				"rollup": "^2.38.5"
+				"rollup": "^2.59.0"
 			},
 			"bin": {
 				"vite": "bin/vite.js"
 			},
 			"engines": {
-				"node": ">=12.0.0"
+				"node": ">=12.2.0"
 			},
 			"optionalDependencies": {
 				"fsevents": "~2.3.2"
+			},
+			"peerDependencies": {
+				"less": "*",
+				"sass": "*",
+				"stylus": "*"
+			},
+			"peerDependenciesMeta": {
+				"less": {
+					"optional": true
+				},
+				"sass": {
+					"optional": true
+				},
+				"stylus": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/which": {
@@ -2473,11 +2751,21 @@
 			"integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
 			"dev": true
 		},
-		"@kahi-ui/framework": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/@kahi-ui/framework/-/framework-0.5.0.tgz",
-			"integrity": "sha512-Yl7YWgv8K+wbPpBPxim9lfeKaMEuBzGZ1hpYjU/GI+KkGZlUY0fhzxtbFxHrdIbXnhFxOqhTq/QrUIMbLD8wfQ==",
+		"@js-temporal/polyfill": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@js-temporal/polyfill/-/polyfill-0.3.0.tgz",
+			"integrity": "sha512-cxxxis19j0WvK3+kUwKrXeXaDBaWxLeRfKqlVz7g50Cly6UgGs2p3wovH9zjtZ4TtjYHDR4De/880+aalduDZQ==",
 			"requires": {
+				"big-integer": "^1.6.51",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@kahi-ui/framework": {
+			"version": "0.5.4",
+			"resolved": "https://registry.npmjs.org/@kahi-ui/framework/-/framework-0.5.4.tgz",
+			"integrity": "sha512-H02Fs/dRgf+6ezio+WKzVWie1iLHDdTpO4eY3UGPuKPMKgQx/VuFaZ7Tc0Eo/3i5B8wp2JNgLChYJFA3O/CxAg==",
+			"requires": {
+				"@js-temporal/polyfill": "^0.3.0",
 				"svelte": "^3.40.2"
 			}
 		},
@@ -2521,9 +2809,9 @@
 			}
 		},
 		"@rollup/pluginutils": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.0.tgz",
-			"integrity": "sha512-TrBhfJkFxA+ER+ew2U2/fHbebhLT/l/2pRk0hfj9KusXUuRXd2v0R58AfaZK9VXDQ4TogOSEmICVrQAA3zFnHQ==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.2.tgz",
+			"integrity": "sha512-ROn4qvkxP9SyPeHaf7uQC/GPFY6L/OWy9+bd9AwcjOAWQwxRscoEyAUD8qCY5o5iL4jqQwoLk2kaTKJPb/HwzQ==",
 			"dev": true,
 			"requires": {
 				"estree-walker": "^2.0.1",
@@ -2531,29 +2819,27 @@
 			}
 		},
 		"@sveltejs/kit": {
-			"version": "1.0.0-next.124",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.124.tgz",
-			"integrity": "sha512-opqmEj/OXJbLEqN+V03mxHvNf53ALT0HUaCmfe5FwQ4Cy5xE8yTlJulB27stnqMPxCeTk5XaCdmN9vDQgd+khA==",
+			"version": "1.0.0-next.240",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.0.0-next.240.tgz",
+			"integrity": "sha512-cHdxdSKAdCuty2lYlRHXE4rJZuKd4wur9U63JtPwysTaReMEJl+s9J/LVvyBzaLW/13x8vm/kKqx+DDcI0udlA==",
 			"dev": true,
 			"requires": {
-				"@sveltejs/vite-plugin-svelte": "^1.0.0-next.12",
-				"cheap-watch": "^1.0.3",
+				"@sveltejs/vite-plugin-svelte": "^1.0.0-next.32",
 				"sade": "^1.7.4",
-				"vite": "^2.4.1"
+				"vite": "^2.7.2"
 			}
 		},
 		"@sveltejs/vite-plugin-svelte": {
-			"version": "1.0.0-next.12",
-			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.12.tgz",
-			"integrity": "sha512-cuyNkJ6leptfv+7qL/fWQ7EpGWdguosFOUI0z93oQUmFTcX7QxJ5h+QI3NQyktBzlKL/761L8BbG2hHNkVbLIQ==",
+			"version": "1.0.0-next.35",
+			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-1.0.0-next.35.tgz",
+			"integrity": "sha512-PuhI+1L6xqn5gc6jiK4mHmeS8kf3c1E+IaAsJclHbZTNiPQdC5SiTM3cV0FAA4zhwHmXV6pjt8rRHRx8ouFv3g==",
 			"dev": true,
 			"requires": {
-				"@rollup/pluginutils": "^4.1.0",
-				"debug": "^4.3.2",
+				"@rollup/pluginutils": "^4.1.2",
+				"debug": "^4.3.3",
 				"kleur": "^4.1.4",
 				"magic-string": "^0.25.7",
-				"require-relative": "^0.8.7",
-				"svelte-hmr": "^0.14.5"
+				"svelte-hmr": "^0.14.9"
 			}
 		},
 		"@types/cookie": {
@@ -2754,6 +3040,11 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true
 		},
+		"big-integer": {
+			"version": "1.6.51",
+			"resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+			"integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg=="
+		},
 		"binary-extensions": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
@@ -2795,12 +3086,6 @@
 				"supports-color": "^7.1.0"
 			}
 		},
-		"cheap-watch": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/cheap-watch/-/cheap-watch-1.0.3.tgz",
-			"integrity": "sha512-xC5CruMhLzjPwJ5ecUxGu1uGmwJQykUhqd2QrCrYbwvsFYdRyviu6jG9+pccwDXJR/OpmOTOJ9yLFunVgQu9wg==",
-			"dev": true
-		},
 		"chokidar": {
 			"version": "3.5.2",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
@@ -2832,12 +3117,6 @@
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true
 		},
-		"colorette": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
-			"integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
-			"dev": true
-		},
 		"concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2861,9 +3140,9 @@
 			}
 		},
 		"debug": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-			"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
 			"dev": true,
 			"requires": {
 				"ms": "2.1.2"
@@ -2915,10 +3194,148 @@
 			}
 		},
 		"esbuild": {
-			"version": "0.12.15",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.12.15.tgz",
-			"integrity": "sha512-72V4JNd2+48eOVCXx49xoSWHgC3/cCy96e7mbXKY+WOWghN00cCmlGnwVLRhRHorvv0dgCyuMYBZlM2xDM5OQw==",
-			"dev": true
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.13.15.tgz",
+			"integrity": "sha512-raCxt02HBKv8RJxE8vkTSCXGIyKHdEdGfUmiYb8wnabnaEmHzyW7DCHb5tEN0xU8ryqg5xw54mcwnYkC4x3AIw==",
+			"dev": true,
+			"requires": {
+				"esbuild-android-arm64": "0.13.15",
+				"esbuild-darwin-64": "0.13.15",
+				"esbuild-darwin-arm64": "0.13.15",
+				"esbuild-freebsd-64": "0.13.15",
+				"esbuild-freebsd-arm64": "0.13.15",
+				"esbuild-linux-32": "0.13.15",
+				"esbuild-linux-64": "0.13.15",
+				"esbuild-linux-arm": "0.13.15",
+				"esbuild-linux-arm64": "0.13.15",
+				"esbuild-linux-mips64le": "0.13.15",
+				"esbuild-linux-ppc64le": "0.13.15",
+				"esbuild-netbsd-64": "0.13.15",
+				"esbuild-openbsd-64": "0.13.15",
+				"esbuild-sunos-64": "0.13.15",
+				"esbuild-windows-32": "0.13.15",
+				"esbuild-windows-64": "0.13.15",
+				"esbuild-windows-arm64": "0.13.15"
+			}
+		},
+		"esbuild-android-arm64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.13.15.tgz",
+			"integrity": "sha512-m602nft/XXeO8YQPUDVoHfjyRVPdPgjyyXOxZ44MK/agewFFkPa8tUo6lAzSWh5Ui5PB4KR9UIFTSBKh/RrCmg==",
+			"dev": true,
+			"optional": true
+		},
+		"esbuild-darwin-64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.13.15.tgz",
+			"integrity": "sha512-ihOQRGs2yyp7t5bArCwnvn2Atr6X4axqPpEdCFPVp7iUj4cVSdisgvEKdNR7yH3JDjW6aQDw40iQFoTqejqxvQ==",
+			"dev": true,
+			"optional": true
+		},
+		"esbuild-darwin-arm64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.13.15.tgz",
+			"integrity": "sha512-i1FZssTVxUqNlJ6cBTj5YQj4imWy3m49RZRnHhLpefFIh0To05ow9DTrXROTE1urGTQCloFUXTX8QfGJy1P8dQ==",
+			"dev": true,
+			"optional": true
+		},
+		"esbuild-freebsd-64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.13.15.tgz",
+			"integrity": "sha512-G3dLBXUI6lC6Z09/x+WtXBXbOYQZ0E8TDBqvn7aMaOCzryJs8LyVXKY4CPnHFXZAbSwkCbqiPuSQ1+HhrNk7EA==",
+			"dev": true,
+			"optional": true
+		},
+		"esbuild-freebsd-arm64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.13.15.tgz",
+			"integrity": "sha512-KJx0fzEDf1uhNOZQStV4ujg30WlnwqUASaGSFPhznLM/bbheu9HhqZ6mJJZM32lkyfGJikw0jg7v3S0oAvtvQQ==",
+			"dev": true,
+			"optional": true
+		},
+		"esbuild-linux-32": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.13.15.tgz",
+			"integrity": "sha512-ZvTBPk0YWCLMCXiFmD5EUtB30zIPvC5Itxz0mdTu/xZBbbHJftQgLWY49wEPSn2T/TxahYCRDWun5smRa0Tu+g==",
+			"dev": true,
+			"optional": true
+		},
+		"esbuild-linux-64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.13.15.tgz",
+			"integrity": "sha512-eCKzkNSLywNeQTRBxJRQ0jxRCl2YWdMB3+PkWFo2BBQYC5mISLIVIjThNtn6HUNqua1pnvgP5xX0nHbZbPj5oA==",
+			"dev": true,
+			"optional": true
+		},
+		"esbuild-linux-arm": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.13.15.tgz",
+			"integrity": "sha512-wUHttDi/ol0tD8ZgUMDH8Ef7IbDX+/UsWJOXaAyTdkT7Yy9ZBqPg8bgB/Dn3CZ9SBpNieozrPRHm0BGww7W/jA==",
+			"dev": true,
+			"optional": true
+		},
+		"esbuild-linux-arm64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.13.15.tgz",
+			"integrity": "sha512-bYpuUlN6qYU9slzr/ltyLTR9YTBS7qUDymO8SV7kjeNext61OdmqFAzuVZom+OLW1HPHseBfJ/JfdSlx8oTUoA==",
+			"dev": true,
+			"optional": true
+		},
+		"esbuild-linux-mips64le": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.13.15.tgz",
+			"integrity": "sha512-KlVjIG828uFPyJkO/8gKwy9RbXhCEUeFsCGOJBepUlpa7G8/SeZgncUEz/tOOUJTcWMTmFMtdd3GElGyAtbSWg==",
+			"dev": true,
+			"optional": true
+		},
+		"esbuild-linux-ppc64le": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.13.15.tgz",
+			"integrity": "sha512-h6gYF+OsaqEuBjeesTBtUPw0bmiDu7eAeuc2OEH9S6mV9/jPhPdhOWzdeshb0BskRZxPhxPOjqZ+/OqLcxQwEQ==",
+			"dev": true,
+			"optional": true
+		},
+		"esbuild-netbsd-64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.13.15.tgz",
+			"integrity": "sha512-3+yE9emwoevLMyvu+iR3rsa+Xwhie7ZEHMGDQ6dkqP/ndFzRHkobHUKTe+NCApSqG5ce2z4rFu+NX/UHnxlh3w==",
+			"dev": true,
+			"optional": true
+		},
+		"esbuild-openbsd-64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.13.15.tgz",
+			"integrity": "sha512-wTfvtwYJYAFL1fSs8yHIdf5GEE4NkbtbXtjLWjM3Cw8mmQKqsg8kTiqJ9NJQe5NX/5Qlo7Xd9r1yKMMkHllp5g==",
+			"dev": true,
+			"optional": true
+		},
+		"esbuild-sunos-64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.13.15.tgz",
+			"integrity": "sha512-lbivT9Bx3t1iWWrSnGyBP9ODriEvWDRiweAs69vI+miJoeKwHWOComSRukttbuzjZ8r1q0mQJ8Z7yUsDJ3hKdw==",
+			"dev": true,
+			"optional": true
+		},
+		"esbuild-windows-32": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.13.15.tgz",
+			"integrity": "sha512-fDMEf2g3SsJ599MBr50cY5ve5lP1wyVwTe6aLJsM01KtxyKkB4UT+fc5MXQFn3RLrAIAZOG+tHC+yXObpSn7Nw==",
+			"dev": true,
+			"optional": true
+		},
+		"esbuild-windows-64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.13.15.tgz",
+			"integrity": "sha512-9aMsPRGDWCd3bGjUIKG/ZOJPKsiztlxl/Q3C1XDswO6eNX/Jtwu4M+jb6YDH9hRSUflQWX0XKAfWzgy5Wk54JQ==",
+			"dev": true,
+			"optional": true
+		},
+		"esbuild-windows-arm64": {
+			"version": "0.13.15",
+			"resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.13.15.tgz",
+			"integrity": "sha512-zzvyCVVpbwQQATaf3IG8mu1IwGEiDxKkYUdA4FpoCHi1KtPa13jeScYDjlW0Qh+ebWzpKfR2ZwvqAQkSWNcKjA==",
+			"dev": true,
+			"optional": true
 		},
 		"escape-string-regexp": {
 			"version": "4.0.0",
@@ -3325,9 +3742,9 @@
 			}
 		},
 		"is-core-module": {
-			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
-			"integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
+			"version": "2.8.1",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
+			"integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
 			"dev": true,
 			"requires": {
 				"has": "^1.0.3"
@@ -3496,9 +3913,9 @@
 			"dev": true
 		},
 		"nanoid": {
-			"version": "3.1.23",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-			"integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
+			"integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
 			"dev": true
 		},
 		"natural-compare": {
@@ -3569,6 +3986,12 @@
 			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
 			"dev": true
 		},
+		"picocolors": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+			"dev": true
+		},
 		"picomatch": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -3576,14 +3999,14 @@
 			"dev": true
 		},
 		"postcss": {
-			"version": "8.3.5",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.5.tgz",
-			"integrity": "sha512-NxTuJocUhYGsMiMFHDUkmjSKT3EdH4/WbGF6GCi1NDGk+vbcUTun4fpbOqaPtD8IIsztA2ilZm2DhYCuyN58gA==",
+			"version": "8.4.5",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.5.tgz",
+			"integrity": "sha512-jBDboWM8qpaqwkMwItqTQTiFikhs/67OYVvblFFTM7MrZjt6yMKd6r2kgXizEbTTljacm4NldIlZnhbjr84QYg==",
 			"dev": true,
 			"requires": {
-				"colorette": "^1.2.2",
-				"nanoid": "^3.1.23",
-				"source-map-js": "^0.6.2"
+				"nanoid": "^3.1.30",
+				"picocolors": "^1.0.0",
+				"source-map-js": "^1.0.1"
 			}
 		},
 		"prelude-ls": {
@@ -3644,20 +4067,15 @@
 			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
 			"dev": true
 		},
-		"require-relative": {
-			"version": "0.8.7",
-			"resolved": "https://registry.npmjs.org/require-relative/-/require-relative-0.8.7.tgz",
-			"integrity": "sha1-eZlTn8ngR6N5KPoZb44VY9q9Nt4=",
-			"dev": true
-		},
 		"resolve": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-			"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+			"version": "1.22.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
+			"integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
 			"dev": true,
 			"requires": {
-				"is-core-module": "^2.2.0",
-				"path-parse": "^1.0.6"
+				"is-core-module": "^2.8.1",
+				"path-parse": "^1.0.7",
+				"supports-preserve-symlinks-flag": "^1.0.0"
 			}
 		},
 		"resolve-from": {
@@ -3682,9 +4100,9 @@
 			}
 		},
 		"rollup": {
-			"version": "2.53.1",
-			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.53.1.tgz",
-			"integrity": "sha512-yiTCvcYXZEulNWNlEONOQVlhXA/hgxjelFSjNcrwAAIfYx/xqjSHwqg/cCaWOyFRKr+IQBaXwt723m8tCaIUiw==",
+			"version": "2.66.1",
+			"resolved": "https://registry.npmjs.org/rollup/-/rollup-2.66.1.tgz",
+			"integrity": "sha512-crSgLhSkLMnKr4s9iZ/1qJCplgAgrRY+igWv8KhG/AjKOJ0YX/WpmANyn8oxrw+zenF3BXWDLa7Xl/QZISH+7w==",
 			"dev": true,
 			"requires": {
 				"fsevents": "~2.3.2"
@@ -3756,9 +4174,9 @@
 			"dev": true
 		},
 		"source-map-js": {
-			"version": "0.6.2",
-			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
-			"integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
 			"dev": true
 		},
 		"sourcemap-codec": {
@@ -3817,10 +4235,16 @@
 				"has-flag": "^4.0.0"
 			}
 		},
+		"supports-preserve-symlinks-flag": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+			"integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+			"dev": true
+		},
 		"svelte": {
-			"version": "3.42.1",
-			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.42.1.tgz",
-			"integrity": "sha512-XtExLd2JAU3T7M2g/DkO3UNj/3n1WdTXrfL63OZ5nZq7nAqd9wQw+lR4Pv/wkVbrWbAIPfLDX47UjFdmnY+YtQ=="
+			"version": "3.46.2",
+			"resolved": "https://registry.npmjs.org/svelte/-/svelte-3.46.2.tgz",
+			"integrity": "sha512-RXSAtYNefe01Sb1lXtZ2I+gzn3t/h/59hoaRNeRrm8IkMIu6BSiAkbpi41xb+C44x54YKnbk9+dtfs3pM4hECA=="
 		},
 		"svelte-check": {
 			"version": "2.2.2",
@@ -3840,9 +4264,9 @@
 			}
 		},
 		"svelte-hmr": {
-			"version": "0.14.5",
-			"resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.14.5.tgz",
-			"integrity": "sha512-3O+kkbT1XKAomKB0LRcdY8JUTzONoNZ8rSH4iEdG7piIYsw+KkXpTkbbU1Sc1yPY4onfXkmCrHElYsxr0V1Snw==",
+			"version": "0.14.9",
+			"resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.14.9.tgz",
+			"integrity": "sha512-bKE9+4qb4sAnA+TKHiYurUl970rjA0XmlP9TEP7K/ncyWz3m81kA4HOgmlZK/7irGK7gzZlaPDI3cmf8fp/+tg==",
 			"dev": true,
 			"requires": {}
 		},
@@ -3908,10 +4332,9 @@
 			}
 		},
 		"tslib": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-			"integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
-			"dev": true
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+			"integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
 		},
 		"tsutils": {
 			"version": "3.21.0",
@@ -3967,16 +4390,16 @@
 			"dev": true
 		},
 		"vite": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-2.4.1.tgz",
-			"integrity": "sha512-4BpKRis9uxIqPfIEcJ18LTBsamqnDFxTx45CXwagHjNltHa6PFEvf8Pe6OpgIHb0OyWT30OXOSSQvdOaX4OBiQ==",
+			"version": "2.7.13",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-2.7.13.tgz",
+			"integrity": "sha512-Mq8et7f3aK0SgSxjDNfOAimZGW9XryfHRa/uV0jseQSilg+KhYDSoNb9h1rknOy6SuMkvNDLKCYAYYUMCE+IgQ==",
 			"dev": true,
 			"requires": {
-				"esbuild": "^0.12.8",
+				"esbuild": "^0.13.12",
 				"fsevents": "~2.3.2",
-				"postcss": "^8.3.5",
+				"postcss": "^8.4.5",
 				"resolve": "^1.20.0",
-				"rollup": "^2.38.5"
+				"rollup": "^2.59.0"
 			}
 		},
 		"which": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
 		"format": "prettier --write --plugin-search-dir=. ."
 	},
 	"devDependencies": {
-		"@sveltejs/kit": "next",
+		"@sveltejs/kit": "^1.0.0-next.240",
 		"@types/cookie": "^0.4.0",
 		"@typescript-eslint/eslint-plugin": "^4.19.0",
 		"@typescript-eslint/parser": "^4.19.0",
@@ -28,7 +28,7 @@
 	},
 	"type": "module",
 	"dependencies": {
-		"@kahi-ui/framework": "^0.5.0",
+		"@kahi-ui/framework": "^0.5.4",
 		"@lukeed/uuid": "^2.0.0",
 		"cookie": "^0.4.1"
 	}

--- a/src/app.html
+++ b/src/app.html
@@ -2,9 +2,9 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<link rel="icon" href="/favicon.png" />
+		<meta name="description" content="Svelte demo app" />
+		<link rel="icon" href="%svelte.assets%/favicon.png" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-
 		%svelte.head%
 	</head>
 	<body>

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -2,21 +2,22 @@ import cookie from 'cookie';
 import { v4 as uuid } from '@lukeed/uuid';
 import type { Handle } from '@sveltejs/kit';
 
-export const handle: Handle = async ({ request, resolve }) => {
-	const cookies = cookie.parse(request.headers.cookie || '');
-	request.locals.userid = cookies.userid || uuid();
+export const handle: Handle = async ({ event, resolve }) => {
+	const cookies = cookie.parse(event.request.headers.get('cookie') || '');
+	event.locals.userid = cookies.userid || uuid();
 
-	// TODO https://github.com/sveltejs/kit/issues/1046
-	if (request.query.has('_method')) {
-		request.method = request.query.get('_method').toUpperCase();
-	}
-
-	const response = await resolve(request);
+	const response = await resolve(event);
 
 	if (!cookies.userid) {
 		// if this is the first time the user has visited this app,
 		// set a cookie so that we recognise them when they return
-		response.headers['set-cookie'] = `userid=${request.locals.userid}; Path=/; HttpOnly`;
+		response.headers.set(
+			'set-cookie',
+			cookie.serialize('userid', event.locals.userid, {
+				path: '/',
+				httpOnly: true
+			})
+		);
 	}
 
 	return response;

--- a/src/lib/Header/index.svelte
+++ b/src/lib/Header/index.svelte
@@ -12,9 +12,9 @@
 
 	<Omni.Footer>
 		<Menu.Container orientation="horizontal" hidden="mobile">
-			<Menu.Anchor href="/" active={$page.path === '/'}>Home</Menu.Anchor>
-			<Menu.Anchor href="/about" active={$page.path === '/about'}>About</Menu.Anchor>
-			<Menu.Anchor href="/todos" active={$page.path === '/todos'}>Todos</Menu.Anchor>
+			<Menu.Anchor href="/" active={$page.url.pathname === '/'}>Home</Menu.Anchor>
+			<Menu.Anchor href="/about" active={$page.url.pathname === '/about'}>About</Menu.Anchor>
+			<Menu.Anchor href="/todos" active={$page.url.pathname === '/todos'}>Todos</Menu.Anchor>
 		</Menu.Container>
 
 		<Popover.Container
@@ -27,9 +27,9 @@
 			<Popover.Section alignment_x="left" spacing="small">
 				<Box palette="auto" elevation="high" padding="medium" shape="rounded">
 					<Menu.Container>
-						<Menu.Anchor href="/" active={$page.path === '/'}>Home</Menu.Anchor>
-						<Menu.Anchor href="/about" active={$page.path === '/about'}>About</Menu.Anchor>
-						<Menu.Anchor href="/todos" active={$page.path === '/todos'}>Todos</Menu.Anchor>
+						<Menu.Anchor href="/" active={$page.url.pathname === '/'}>Home</Menu.Anchor>
+						<Menu.Anchor href="/about" active={$page.url.pathname === '/about'}>About</Menu.Anchor>
+						<Menu.Anchor href="/todos" active={$page.url.pathname === '/todos'}>Todos</Menu.Anchor>
 					</Menu.Container>
 				</Box>
 			</Popover.Section>

--- a/src/lib/form.ts
+++ b/src/lib/form.ts
@@ -8,11 +8,11 @@ export function enhance(
 		result
 	}: {
 		pending?: (data: FormData, form: HTMLFormElement) => void;
-		error?: (res: Response, error: Error, form: HTMLFormElement) => void;
+		error?: (res: Response | null, error: Error | null, form: HTMLFormElement) => void;
 		result: (res: Response, form: HTMLFormElement) => void;
 	}
-) {
-	let current_token: {};
+): { destroy: () => void } {
+	let current_token: unknown;
 
 	async function handle_submit(e: Event) {
 		const token = (current_token = {});
@@ -41,7 +41,7 @@ export function enhance(
 			} else {
 				console.error(await res.text());
 			}
-		} catch (e) {
+		} catch (e: any) {
 			if (error) {
 				error(null, e, form);
 			} else {

--- a/src/routes/todos/[uid].json.ts
+++ b/src/routes/todos/[uid].json.ts
@@ -3,14 +3,16 @@ import type { RequestHandler } from '@sveltejs/kit';
 import type { Locals } from '$lib/types';
 
 // PATCH /todos/:uid.json
-export const patch: RequestHandler<Locals, FormData> = async (request) => {
-	return api(request, `todos/${request.locals.userid}/${request.params.uid}`, {
-		text: request.body.get('text'),
-		done: request.body.has('done') ? !!request.body.get('done') : undefined
+export const patch: RequestHandler<Locals> = async (event) => {
+	const data = await event.request.formData();
+
+	return api(event, `todos/${event.locals.userid}/${event.params.uid}`, {
+		text: data.get('text'),
+		done: data.has('done') ? !!data.get('done') : undefined
 	});
 };
 
 // DELETE /todos/:uid.json
-export const del: RequestHandler<Locals> = async (request) => {
-	return api(request, `todos/${request.locals.userid}/${request.params.uid}`);
+export const del: RequestHandler<Locals> = async (event) => {
+	return api(event, `todos/${event.locals.userid}/${event.params.uid}`);
 };

--- a/src/routes/todos/_api.ts
+++ b/src/routes/todos/_api.ts
@@ -1,4 +1,4 @@
-import type { Request } from '@sveltejs/kit';
+import type { EndpointOutput, RequestEvent } from '@sveltejs/kit';
 import type { Locals } from '$lib/types';
 
 /*
@@ -14,14 +14,18 @@ import type { Locals } from '$lib/types';
 
 const base = 'https://api.svelte.dev';
 
-export async function api(request: Request<Locals>, resource: string, data?: {}) {
+export async function api(
+	event: RequestEvent<Locals>,
+	resource: string,
+	data?: Record<string, unknown>
+): Promise<EndpointOutput> {
 	// user must have a cookie set
-	if (!request.locals.userid) {
+	if (!event.locals.userid) {
 		return { status: 401 };
 	}
 
 	const res = await fetch(`${base}/${resource}`, {
-		method: request.method,
+		method: event.request.method,
 		headers: {
 			'content-type': 'application/json'
 		},
@@ -32,7 +36,11 @@ export async function api(request: Request<Locals>, resource: string, data?: {})
 	// behaviour is to show the URL corresponding to the form's "action"
 	// attribute. in those cases, we want to redirect them back to the
 	// /todos page, rather than showing the response
-	if (res.ok && request.method !== 'GET' && request.headers.accept !== 'application/json') {
+	if (
+		res.ok &&
+		event.request.method !== 'GET' &&
+		event.request.headers.get('accept') !== 'application/json'
+	) {
 		return {
 			status: 303,
 			headers: {

--- a/src/routes/todos/index.json.ts
+++ b/src/routes/todos/index.json.ts
@@ -3,9 +3,9 @@ import type { RequestHandler } from '@sveltejs/kit';
 import type { Locals } from '$lib/types';
 
 // GET /todos.json
-export const get: RequestHandler<Locals> = async (request) => {
-	// request.locals.userid comes from src/hooks.js
-	const response = await api(request, `todos/${request.locals.userid}`);
+export const get: RequestHandler<Locals> = async (event) => {
+	// event.locals.userid comes from src/hooks.js
+	const response = await api(event, `todos/${event.locals.userid}`);
 
 	if (response.status === 404) {
 		// user hasn't created a todo list.
@@ -17,13 +17,15 @@ export const get: RequestHandler<Locals> = async (request) => {
 };
 
 // POST /todos.json
-export const post: RequestHandler<Locals, FormData> = async (request) => {
-	const response = await api(request, `todos/${request.locals.userid}`, {
+export const post: RequestHandler<Locals> = async (event) => {
+	const data = await event.request.formData();
+
+	const response = await api(event, `todos/${event.locals.userid}`, {
 		// because index.svelte posts a FormData object,
 		// request.body is _also_ a (readonly) FormData
 		// object, which allows us to get form data
 		// with the `body.get(key)` method
-		text: request.body.get('text')
+		text: data.get('text')
 	});
 
 	return response;

--- a/src/routes/todos/index.svelte
+++ b/src/routes/todos/index.svelte
@@ -30,6 +30,7 @@
 		created_at: Date;
 		text: string;
 		done: boolean;
+		pending_delete: boolean;
 	};
 
 	export let todos: Todo[];
@@ -84,7 +85,7 @@
 					<Tile.Header>
 						<form
 							class="text"
-							action="/todos/{todo.uid}.json?_method=patch"
+							action="/todos/{todo.uid}.json?_method=PATCH"
 							method="post"
 							use:enhance={{
 								result: patch
@@ -94,7 +95,7 @@
 								name="text"
 								value={todo.text}
 								variation="flush"
-								on:blur={(event) => on_text_blur(todo.text, event)}
+								on:focusout={(event) => on_text_blur(todo.text, event)}
 							/>
 						</form>
 					</Tile.Header>
@@ -102,7 +103,7 @@
 
 				<Tile.Footer>
 					<form
-						action="/todos/{todo.uid}.json?_method=patch"
+						action="/todos/{todo.uid}.json?_method=PATCH"
 						method="post"
 						use:enhance={{
 							pending: (data) => {
@@ -119,9 +120,10 @@
 					</form>
 
 					<form
-						action="/todos/{todo.uid}.json?_method=delete"
+						action="/todos/{todo.uid}.json?_method=DELETE"
 						method="post"
 						use:enhance={{
+							pending: () => (todo.pending_delete = true),
 							result: () => {
 								todos = todos.filter((t) => t.uid !== todo.uid);
 							}

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -8,7 +8,12 @@ const config = {
 
 	kit: {
 		// hydrate the <div id="svelte"> element in src/app.html
-		target: '#svelte'
+		target: '#svelte',
+
+		// Override http methods in the Todo forms
+		methodOverride: {
+			allowed: ['PATCH', 'DELETE']
+		}
 	}
 };
 


### PR DESCRIPTION
# CHANGELOG

- Bump Kahi UI to `0.5.5`
- Bump and pin SvelteKit to `next.240`
- Updated codebase to reflect breaking changes in newer SvelteKit versions regarding API route signatures 